### PR TITLE
Use embedded yt-dlp binary

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "typescript": "5.2.2",
     "vaul": "^0.9.9",
     "yt-dlp-wrap": "^2.3.12",
+    "yt-dlp-exec": "^1.3.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- use the yt‑dlp-exec binary so yt-dlp works even if Python is missing

## Testing
- `npm run lint --silent` *(fails: `next` not found)*